### PR TITLE
Simplifying place authority for SDP

### DIFF
--- a/data-model/SDP-data-model-templates/place_sdp-template.json
+++ b/data-model/SDP-data-model-templates/place_sdp-template.json
@@ -1,9 +1,19 @@
 {
-  "id": "ARK/URI(?)",
-  "label": "",
+  "id": "URI",
   "type": "CV",
   "place_type": "CV",
   "uniform_name": "",
+  "alt_name": [
+    "array of language-mapped strings"
+  ],
+  "role": [
+    {
+      "type": "CV of role types",
+      "associated_objects": [
+        "Array of Object ARKs. CMS will pull in the object's label/shelfmark and the place's attributed name information"
+      ]
+    }
+  ],
   "description": [
     "array of strings"
   ],
@@ -13,9 +23,26 @@
       "uniform_name": ""
     }
   ],
-  "associated_entities": [
+  "related_persons": [
     {
-      "entity_type": "CV",
+      "relation": "CV",
+      "id": "URI/ARK",
+      "note": [
+        "array of strings"
+      ]
+    }
+  ],
+  "related_places": [
+    {
+      "relation": "CV",
+      "id": "URI/ARK",
+      "note": [
+        "array of strings"
+      ]
+    }
+  ],
+  "related_works": [
+    {
       "relation": "CV",
       "id": "URI/ARK",
       "note": [
@@ -31,13 +58,6 @@
       "note": [
         ""
       ]
-    }
-  ],
-  "location": [
-    {
-      "type": "CV",
-      "coordinates": "",
-      "source": "URI?"
     }
   ],
   "note": [
@@ -73,7 +93,18 @@
       ]
     }
   ],
-  "contributor": [
-    "array of strings (CV)"
-  ]
+  "meta": {
+    "contributor": [
+      "array of strings (CV); auto-populated based on the change_log?"
+    ],
+    "last_updated": "xsd:dateTime",
+    "change_log": [
+      {
+        "date": "xsd:dateTime",
+        "contributor": "CV of Contributor Name (or URI?). Auto-populated based on user account (though needs to be editable to credit a contributing scholar rather than a data entry person)",
+        "change": "string describing what change was made?"
+      }
+    ],
+    "created": "xsd:dateTime"
+  }
 }


### PR DESCRIPTION
@kirschbombe I made a few changes to places for us to discuss. Mostly these center on bringing places in line with our most recent changes to person and work templates. I also removed 'location', which is part of an effort to refocus these templates to _solely_ be about repositories for data gathered from the Sinai collection (and I don't think that any manuscripts would have GPS coordinates in the colophon 😄 )

I'll make a few notes in the diff file.