### PR TITLE
Further object revisions wlpotter

### DIFF
--- a/data-model/SDP-data-model-templates/codicological-unit_sdp-template.json
+++ b/data-model/SDP-data-model-templates/codicological-unit_sdp-template.json
@@ -15,6 +15,9 @@
       ],
       "features": [
         "array of CV"
+      ],
+      "range": [
+        "array of strings"
       ]
     }
   ],
@@ -32,7 +35,10 @@
       "writing_system": "CV",
       "script": "CV",
       "ink_color": "CV",
-      "note": [
+      "script_note": [
+        "array of strings"
+      ],
+      "hand_note": [
         "array of strings"
       ],
       "features": [
@@ -77,11 +83,9 @@
     {
       "id": "URI",
       "type": "CV",
-      "note": [
-        "array of strings"
-      ],
-      "associated_dates": [
+      "associated_date": [
         {
+          "date_type": "CV",
           "date_human_readable": "",
           "date_normalized": "ISO-8601 Dates",
           "note": [
@@ -89,40 +93,66 @@
           ]
         }
       ],
-      "associated_entities": [
+      "associated_person": [
         {
-          "entity_type": "CV",
-          "role": "CV",
-          "id": "URI/ARK",
+          "relation": "CV",
+          "id": "URI",
           "note": [
             "array of strings"
           ]
         }
       ],
+      "associated_place": [
+        {
+          "relation": "CV",
+          "id": "URI",
+          "note": [
+            "array of strings"
+          ]
+        }
+      ],
+      "note": [
+        "array of strings"
+      ],
       "sources": [
-        "ARK/ID of a Paratext? URI of a Zotero Bibl?"
+        "Paratext ARKs | Zotero URI(?)"
       ]
     }
   ],
-  "paratexts": [
-    {
-      "id": "ARK",
-      "type": "CV",
-      "locus": "",
-      "transcription": {
-        "$langCode": "Note: lang code refers to the language of transcribed text. transcription object may have multiple $langCode fields."
-      },
-      "translation": {
-        "$langCode": "Note: lang code refers to the language of translated text. translation object may have multiple $langCode fields."
-      },
-      "note": [
-        ""
-      ],
-      "attested_entities": {
+  "paratexts": {
+    "colophon": [
+      {
+        "id": "ARK",
+        "type": "CV",
+        "locus": [
+          "array of strings"
+        ],
+        "transcription": [
+          {
+            "syr": "note: field name is an ISO language code"
+          }
+        ],
+        "translation": [
+          {
+            "en": "note: field name is an ISO langcode"
+          }
+        ],
         "attested_person": [
           {
             "relation": "CV",
             "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
             "note": [
               "array of strings"
             ]
@@ -132,35 +162,142 @@
           {
             "relation": "CV",
             "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
             "note": [
               "array of strings"
             ]
           }
-        ]
-      }
-    }
-  ],
-  "associated_entities": {
-    "associated_person": [
-      {
-        "relation": "CV",
-        "id": "URI",
-        "note": [
-          "array of strings"
+        ],
+        "attested_date": [
+          {
+            "type": "CV",
+            "dating_method": "CV",
+            "transcription": [
+              {
+                "syr": "note: field name is an ISO language code"
+              }
+            ],
+            "translation": [
+              {
+                "en": "note: field name is an ISO langcode"
+              }
+            ],
+            "date_human_readable": "Conversion of the date into a Gregorian calendar system, but still a human readable label",
+            "date_normalized": "ISO 8601 date/date range"
+          }
         ]
       }
     ],
-    "associated_place": [
+    "inscription": [
       {
-        "relation": "CV",
-        "id": "URI",
-        "note": [
+        "id": "ARK",
+        "type": "CV",
+        "locus": [
           "array of strings"
+        ],
+        "transcription": [
+          {
+            "syr": "note: field name is an ISO language code"
+          }
+        ],
+        "translation": [
+          {
+            "en": "note: field name is an ISO langcode"
+          }
+        ],
+        "attested_person": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_place": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_date": [
+          {
+            "type": "CV",
+            "dating_method": "CV",
+            "transcription": [
+              {
+                "syr": "note: field name is an ISO language code"
+              }
+            ],
+            "translation": [
+              {
+                "en": "note: field name is an ISO langcode"
+              }
+            ],
+            "date_human_readable": "Conversion of the date into a Gregorian calendar system, but still a human readable label",
+            "date_normalized": "ISO 8601 date/date range"
+          }
         ]
       }
     ]
   },
-  "associated_dates": [
+  "associated_person": [
+    {
+      "relation": "CV",
+      "id": "URI",
+      "note": [
+        "array of strings"
+      ]
+    }
+  ],
+  "associated_place": [
+    {
+      "relation": "CV",
+      "id": "URI",
+      "note": [
+        "array of strings"
+      ]
+    }
+  ],
+  "associated_date": [
     {
       "date_type": "CV",
       "date_human_readable": "",
@@ -219,11 +356,13 @@
       ]
     }
   ],
+  "other_versions": [
+    "array of URIs"
+  ],
   "iiif": {
     "iiif_manifest": "Manifest URL",
     "text_direction": "CV",
-    "viewing_hint": "CV",
-    "range": "???"
+    "viewing_hint": "CV"
   },
   "related_objects": {
     "has_content": [

--- a/data-model/SDP-data-model-templates/codicological-unit_sdp-template.json
+++ b/data-model/SDP-data-model-templates/codicological-unit_sdp-template.json
@@ -54,8 +54,8 @@
   ],
   "page_layout": [
     {
-      "columns": "int",
-      "number_of_lines": "int",
+      "columns": "",
+      "number_of_lines": "",
       "column_width": "",
       "margin_width": "",
       "note": [

--- a/data-model/SDP-data-model-templates/manuscript-object_sdp-template.json
+++ b/data-model/SDP-data-model-templates/manuscript-object_sdp-template.json
@@ -39,11 +39,9 @@
     {
       "id": "URI",
       "type": "CV",
-      "note": [
-        "array of strings"
-      ],
-      "associated_dates": [
+      "associated_date": [
         {
+          "date_type": "CV",
           "date_human_readable": "",
           "date_normalized": "ISO-8601 Dates",
           "note": [
@@ -51,23 +49,114 @@
           ]
         }
       ],
-      "associated_entities": [
+      "associated_person": [
         {
-          "entity_type": "CV",
-          "role": "CV",
-          "id": "URI/ARK",
+          "relation": "CV",
+          "id": "URI",
           "note": [
             "array of strings"
           ]
         }
       ],
+      "associated_place": [
+        {
+          "relation": "CV",
+          "id": "URI",
+          "note": [
+            "array of strings"
+          ]
+        }
+      ],
+      "note": [
+        "array of strings"
+      ],
       "sources": [
-        "ARK/ID of a Paratext? URI of a Zotero Bibl?"
+        "Paratext ARKs | Zotero URI(?)"
       ]
     }
   ],
-  "associated_entities": {
-    "associated_person": [
+  "paratexts": {
+    "inscription": [
+      {
+        "id": "ARK",
+        "type": "CV",
+        "locus": [
+          "array of strings"
+        ],
+        "transcription": [
+          {
+            "syr": "note: field name is an ISO language code"
+          }
+        ],
+        "translation": [
+          {
+            "en": "note: field name is an ISO langcode"
+          }
+        ],
+        "attested_person": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_place": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_date": [
+          {
+            "type": "CV",
+            "dating_method": "CV",
+            "transcription": [
+              {
+                "syr": "note: field name is an ISO language code"
+              }
+            ],
+            "translation": [
+              {
+                "en": "note: field name is an ISO langcode"
+              }
+            ],
+            "date_human_readable": "Conversion of the date into a Gregorian calendar system, but still a human readable label",
+            "date_normalized": "ISO 8601 date/date range"
+          }
+        ]
+      }
+    ]
+  },
+  "associated_person": [
       {
         "relation": "CV",
         "id": "URI",
@@ -76,7 +165,7 @@
         ]
       }
     ],
-    "associated_place": [
+  "associated_place": [
       {
         "relation": "CV",
         "id": "URI",
@@ -84,9 +173,8 @@
           "array of strings"
         ]
       }
-    ]
-  },
-  "associated_dates": [
+    ],
+  "associated_date": [
     {
       "date_type": "CV",
       "date_human_readable": "",
@@ -132,11 +220,14 @@
       ]
     }
   ],
+  "other_versions": [
+    "array of URIs"
+  ],
   "iiif": {
     "iiif_manifest": "Manifest URL",
     "text_direction": "CV",
     "viewing_hint": "CV",
-    "range": "???"
+    "thumbnail_url": "IIIF Image URL"
   },
   "related_objects": {
     "has_part": [
@@ -160,6 +251,7 @@
         "change": "string describing what change was made?"
       }
     ],
-    "created": "xsd:dateTime"
+    "created": "xsd:dateTime",
+    "delivery": ""
   }
 }

--- a/data-model/SDP-data-model-templates/textual-artifact_sdp-template.json
+++ b/data-model/SDP-data-model-templates/textual-artifact_sdp-template.json
@@ -7,6 +7,20 @@
   ],
   "extent": "",
   "embodies": "URI of Work Authority File",
+  "attested_title": {
+    "transcription": [
+      {
+        "syr": "field name must be an ISO language code"
+      }
+    ],
+    "translation": [
+      {
+        "en": "field name must be an ISO language code"
+      }
+    ],
+    "locus": ""
+  },
+  "supplied_title": "",
   "condition": {
     "note": [
       "array of strings"
@@ -30,11 +44,9 @@
     {
       "id": "URI",
       "type": "CV",
-      "note": [
-        "array of strings"
-      ],
-      "associated_dates": [
+      "associated_date": [
         {
+          "date_type": "CV",
           "date_human_readable": "",
           "date_normalized": "ISO-8601 Dates",
           "note": [
@@ -42,40 +54,66 @@
           ]
         }
       ],
-      "associated_entities": [
+      "associated_person": [
         {
-          "entity_type": "CV",
-          "role": "CV",
-          "id": "URI/ARK",
+          "relation": "CV",
+          "id": "URI",
           "note": [
             "array of strings"
           ]
         }
       ],
+      "associated_place": [
+        {
+          "relation": "CV",
+          "id": "URI",
+          "note": [
+            "array of strings"
+          ]
+        }
+      ],
+      "note": [
+        "array of strings"
+      ],
       "sources": [
-        "ARK/ID of a Paratext? URI of a Zotero Bibl?"
+        "Paratext ARKs | Zotero URI(?)"
       ]
     }
   ],
-  "paratexts": [
-    {
-      "id": "ARK",
-      "type": "CV",
-      "locus": "",
-      "transcription": {
-        "$langCode": "Note: lang code refers to the language of transcribed text. transcription object may have multiple $langCode fields."
-      },
-      "translation": {
-        "$langCode": "Note: lang code refers to the language of translated text. translation object may have multiple $langCode fields."
-      },
-      "note": [
-        ""
-      ],
-      "attested_entities": {
+  "paratexts": {
+    "rubric": [
+      {
+        "id": "ARK",
+        "type": "CV",
+        "locus": [
+          "array of strings"
+        ],
+        "transcription": [
+          {
+            "syr": "note: field name is an ISO language code"
+          }
+        ],
+        "translation": [
+          {
+            "en": "note: field name is an ISO langcode"
+          }
+        ],
         "attested_person": [
           {
             "relation": "CV",
             "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
             "note": [
               "array of strings"
             ]
@@ -85,35 +123,458 @@
           {
             "relation": "CV",
             "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
             "note": [
               "array of strings"
             ]
           }
-        ]
-      }
-    }
-  ],
-  "associated_entities": {
-    "associated_person": [
-      {
-        "relation": "CV",
-        "id": "URI",
-        "note": [
-          "array of strings"
+        ],
+        "attested_date": [
+          {
+            "type": "CV",
+            "dating_method": "CV",
+            "transcription": [
+              {
+                "syr": "note: field name is an ISO language code"
+              }
+            ],
+            "translation": [
+              {
+                "en": "note: field name is an ISO langcode"
+              }
+            ],
+            "date_human_readable": "Conversion of the date into a Gregorian calendar system, but still a human readable label",
+            "date_normalized": "ISO 8601 date/date range"
+          }
         ]
       }
     ],
-    "associated_place": [
+    "prologue": [
       {
-        "relation": "CV",
-        "id": "URI",
-        "note": [
+        "id": "ARK",
+        "type": "CV",
+        "locus": [
           "array of strings"
+        ],
+        "transcription": [
+          {
+            "syr": "note: field name is an ISO language code"
+          }
+        ],
+        "translation": [
+          {
+            "en": "note: field name is an ISO langcode"
+          }
+        ],
+        "attested_person": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_place": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_date": [
+          {
+            "type": "CV",
+            "dating_method": "CV",
+            "transcription": [
+              {
+                "syr": "note: field name is an ISO language code"
+              }
+            ],
+            "translation": [
+              {
+                "en": "note: field name is an ISO langcode"
+              }
+            ],
+            "date_human_readable": "Conversion of the date into a Gregorian calendar system, but still a human readable label",
+            "date_normalized": "ISO 8601 date/date range"
+          }
+        ]
+      }
+    ],
+    "incipit": [
+      {
+        "id": "ARK",
+        "type": "CV",
+        "locus": [
+          "array of strings"
+        ],
+        "transcription": [
+          {
+            "syr": "note: field name is an ISO language code"
+          }
+        ],
+        "translation": [
+          {
+            "en": "note: field name is an ISO langcode"
+          }
+        ],
+        "attested_person": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_place": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_date": [
+          {
+            "type": "CV",
+            "dating_method": "CV",
+            "transcription": [
+              {
+                "syr": "note: field name is an ISO language code"
+              }
+            ],
+            "translation": [
+              {
+                "en": "note: field name is an ISO langcode"
+              }
+            ],
+            "date_human_readable": "Conversion of the date into a Gregorian calendar system, but still a human readable label",
+            "date_normalized": "ISO 8601 date/date range"
+          }
+        ]
+      }
+    ],
+    "explicit": [
+      {
+        "id": "ARK",
+        "type": "CV",
+        "locus": [
+          "array of strings"
+        ],
+        "transcription": [
+          {
+            "syr": "note: field name is an ISO language code"
+          }
+        ],
+        "translation": [
+          {
+            "en": "note: field name is an ISO langcode"
+          }
+        ],
+        "attested_person": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_place": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_date": [
+          {
+            "type": "CV",
+            "dating_method": "CV",
+            "transcription": [
+              {
+                "syr": "note: field name is an ISO language code"
+              }
+            ],
+            "translation": [
+              {
+                "en": "note: field name is an ISO langcode"
+              }
+            ],
+            "date_human_readable": "Conversion of the date into a Gregorian calendar system, but still a human readable label",
+            "date_normalized": "ISO 8601 date/date range"
+          }
+        ]
+      }
+    ],
+    "subscription": [
+      {
+        "id": "ARK",
+        "type": "CV",
+        "locus": [
+          "array of strings"
+        ],
+        "transcription": [
+          {
+            "syr": "note: field name is an ISO language code"
+          }
+        ],
+        "translation": [
+          {
+            "en": "note: field name is an ISO langcode"
+          }
+        ],
+        "attested_person": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_place": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_date": [
+          {
+            "type": "CV",
+            "dating_method": "CV",
+            "transcription": [
+              {
+                "syr": "note: field name is an ISO language code"
+              }
+            ],
+            "translation": [
+              {
+                "en": "note: field name is an ISO langcode"
+              }
+            ],
+            "date_human_readable": "Conversion of the date into a Gregorian calendar system, but still a human readable label",
+            "date_normalized": "ISO 8601 date/date range"
+          }
+        ]
+      }
+    ],
+    "marginalia": [
+      {
+        "id": "ARK",
+        "type": "CV",
+        "locus": [
+          "array of strings"
+        ],
+        "transcription": [
+          {
+            "syr": "note: field name is an ISO language code"
+          }
+        ],
+        "translation": [
+          {
+            "en": "note: field name is an ISO langcode"
+          }
+        ],
+        "attested_person": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_place": [
+          {
+            "relation": "CV",
+            "id": "URI",
+            "attested_name": {
+              "transcription": [
+                {
+                  "syr": "note: field name is an ISO language code"
+                }
+              ],
+              "translation": [
+                {
+                  "en": "note: field name is an ISO langcode"
+                }
+              ]
+            },
+            "note": [
+              "array of strings"
+            ]
+          }
+        ],
+        "attested_date": [
+          {
+            "type": "CV",
+            "dating_method": "CV",
+            "transcription": [
+              {
+                "syr": "note: field name is an ISO language code"
+              }
+            ],
+            "translation": [
+              {
+                "en": "note: field name is an ISO langcode"
+              }
+            ],
+            "date_human_readable": "Conversion of the date into a Gregorian calendar system, but still a human readable label",
+            "date_normalized": "ISO 8601 date/date range"
+          }
         ]
       }
     ]
   },
-  "associated_dates": [
+  "associated_person": [
+    {
+      "relation": "CV",
+      "id": "URI",
+      "note": [
+        "array of strings"
+      ]
+    }
+  ],
+  "associated_place": [
+    {
+      "relation": "CV",
+      "id": "URI",
+      "note": [
+        "array of strings"
+      ]
+    }
+  ],
+  "associated_date": [
     {
       "date_type": "CV",
       "date_human_readable": "",
@@ -162,8 +623,7 @@
   "iiif": {
     "iiif_manifest": "Manifest URL",
     "text_direction": "CV",
-    "viewing_hint": "CV",
-    "range": "???"
+    "viewing_hint": "CV"
   },
   "related_objects": {
     "contained_in": [


### PR DESCRIPTION
These are additional revisions based on the ones made in #52.

Some of these were uncovered in creating 'real data' exemplars (I will make a separate pull request for adding the exemplars).

A few outstanding issues:

1. Events vs attested dates vs associated dates. How many options do we allow? What will the user flows look like for adding events vs associated dates? Linking attestations to their corresponding events?
    1. More specifically, should we structure events similarly to other data where it is an object with array fields based on top-level event types ("production"; "ownership"; "use"; "custodianship")
2. Textual artifact contents. I've still just left these as 'note', 'features', and 'toc'. There may be more granular detail we'd want to grab about sub-items.

I'll make more specific comments and annotations on the files themselves of the changes I've made for discussion