### PR TITLE
Upgrades deprecated df.append to use pandas.concat

### DIFF
--- a/scripts/airtable-export/sinai_airtable_export.py
+++ b/scripts/airtable-export/sinai_airtable_export.py
@@ -505,8 +505,8 @@ for index, row in dfDelivery.sort_values('Shelfmark').iterrows():
     'delivery': final_delivery.rstrip('\r\n'),
     'image count': str(final_image_count).rstrip('\r\n'),
     'Viscodex': final_viscodex.rstrip('\r\n')}
-
-    dfWorkbook = dfWorkbook.append(new_row, ignore_index=True)
+    dfNewRow = pd.DataFrame([new_row])
+    dfWorkbook = pd.concat([dfWorkbook, dfNewRow], ignore_index=True)
 
 batchNum = batchNum.replace(".", "-")
 


### PR DESCRIPTION
Fixes a pandas warning where the frame.append method was being deprecated in favor of pandas.concat.

I have tested the export script using the new pandas.concat method, and it still works as expected